### PR TITLE
feat: simplify card's summary styles

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -26,6 +26,13 @@
 .AppContainer {
     width: 100%;
 }
+.disabled {
+    opacity: .4;
+    cursor: default!important;
+}
+.disabled:hover {
+    color: var(--text-color)!important;
+}
 .theme-toggler {
     width: 28px;
     margin: 0 8px;
@@ -53,4 +60,5 @@
 h3 {
     font-weight: 600;
     margin-top: 0;
+    text-transform: uppercase;
 }

--- a/src/components/card/Card.js
+++ b/src/components/card/Card.js
@@ -85,9 +85,9 @@ function Card(props) {
                         {fullscreen ? "fullscreen_exit" : "fullscreen"}
                     </em>
                     <em
-                        className={cls(styles.expand, "material-icons")}
+                        className={cls(styles.expand, "material-icons", fullscreen ? 'disabled' : '')}
                         title={expanded ? "contract" : "expand"}
-                        onClick={toggleExpand}
+                        onClick={fullscreen ? null : toggleExpand}
                     >
                         {expanded ? "unfold_less" : "unfold_more"}
                     </em>
@@ -98,7 +98,7 @@ function Card(props) {
             </header>
             {results ? (
                 <RowLayout className={styles.cardBody}>
-                    <ColumnLayout className={styles.summary}>
+                    <ColumnLayout className={cls(styles.summary, fullscreen || expanded ? styles.summaryWidder : '')}>
                         <h3>Summary</h3>
                         <Summary summary={stats} item={item || selected} graphStyle={graphStyle}></Summary>
                     </ColumnLayout>

--- a/src/components/card/Card.module.css
+++ b/src/components/card/Card.module.css
@@ -68,12 +68,13 @@
 }
 
 .summary {
-    background: var(--secondary-color);
-    border-right: 1px solid var(--bg-color);
     padding: 24px;
     width: 132px;
     overflow: scroll;
     transition: all ease-in-out 200ms;
+}
+.summaryWidder {
+    width: 200px;
 }
 .dragger {
     position: absolute;

--- a/src/components/card/Summary.module.css
+++ b/src/components/card/Summary.module.css
@@ -13,9 +13,8 @@
 }
 
 .properties {
-    padding-top: 24px;
-    margin-top: 24px;
-    border-top: 1px solid var(--bg-color);
+    padding-top: 12px;
+    margin-top: 8px;
     overflow: hidden;
     max-width: 100%;
 }


### PR DESCRIPTION
Now summary is styled without background nor borders.

Implements #44 